### PR TITLE
Dynamic check for visible debug menu as opposed to setting variable

### DIFF
--- a/SPDebugMenu/SPDebugMenu.m
+++ b/SPDebugMenu/SPDebugMenu.m
@@ -42,8 +42,6 @@
 @property (nonatomic, strong) NSMutableArray *triggers;
 @property (nonatomic, strong) NSMutableArray *actions;
 
-@property (nonatomic, getter = isMenuVisible) BOOL menuVisible;
-
 @end
 
 #pragma mark - SPDebugMenu class implementation
@@ -124,9 +122,7 @@
 - (void)dismissDebugMenu
 {
     [self.navigationController.presentingViewController dismissViewControllerAnimated:YES
-                                                                           completion:^{
-                                                                               self.menuVisible = NO;
-                                                                           }];
+                                                                           completion:nil];
     self.navigationController = nil;
 }
 
@@ -145,11 +141,11 @@
 
 - (void)debugMenuWasTriggered:(id<SPDebugMenuTriggering>)sender
 {
-    if (self.menuVisible) return;
-    self.menuVisible = YES;
-
-    [self prepareActions];
-    [self showDebugMenu];
+    if (!self.navigationController.view.window)
+    {
+        [self prepareActions];
+        [self showDebugMenu];
+    }
 }
 
 #pragma mark - SPDebugMenuViewControllerDelegate methods

--- a/SPDebugMenu/SPDebugMenu.m
+++ b/SPDebugMenu/SPDebugMenu.m
@@ -42,6 +42,7 @@
 @property (nonatomic, strong) NSMutableArray *triggers;
 @property (nonatomic, strong) NSMutableArray *actions;
 
+@property (nonatomic, assign, readonly) BOOL isMenuVisible;
 @end
 
 #pragma mark - SPDebugMenu class implementation
@@ -141,7 +142,7 @@
 
 - (void)debugMenuWasTriggered:(id<SPDebugMenuTriggering>)sender
 {
-    if (!self.navigationController.view.window)
+    if (!self.isMenuVisible)
     {
         [self prepareActions];
         [self showDebugMenu];
@@ -154,6 +155,12 @@
 {
     [self dismissDebugMenu];
     [self disposeActions];
+}
+
+#pragma mark - Overrides
+
+- (BOOL)isMenuVisible {
+	return !!self.navigationController.view.window;
 }
 
 @end


### PR DESCRIPTION
Removed isVisible variable, as it might not always be unset correctly (ie, if we call dismissViewController manually on the navigationController)
